### PR TITLE
Import to IREE as XLA.

### DIFF
--- a/iree/jax/frontend.py
+++ b/iree/jax/frontend.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Original HLO-proto based function compilation.
 
 This API is being gradually replaced but is supported until an alternative
@@ -65,7 +64,9 @@ def aot(function, *args, **options):
   """
   xla_comp = jax.xla_computation(function)(*args)
   hlo_proto = xla_comp.as_serialized_hlo_module_proto()
-  return iree.compiler.tools.xla.compile_str(hlo_proto, **options)
+  return iree.compiler.tools.xla.compile_str(hlo_proto,
+                                             input_type="xla",
+                                             **options)
 
 
 # A more JAX-native approach to jitting would be desireable here, however

--- a/tests/legacy_xla/frontend_test.py
+++ b/tests/legacy_xla/frontend_test.py
@@ -148,18 +148,6 @@ class JAXFrontendTest(absltest.TestCase):
 
     self.assertEqual(mul_two(3), 6)
 
-  def test_iree_jit_of_empty_iree_jit(self):
-
-    @iree.jax.jit
-    def sqrt_four():
-      return jnp.sqrt(4)
-
-    @iree.jax.jit
-    def add_sqrt_four(a):
-      return a + sqrt_four()
-
-    self.assertEqual(add_sqrt_four(2), 4)
-
   def test_jit_pytree_method(self):
 
     @iree.jax.jit


### PR DESCRIPTION
Also removes an old test that was relying on some unspecified JAX
behavior (and is now failing). The case is not important to preserve
here and was, at best, accidentally working.