### PR TITLE
Update examples for iree.jax updates

### DIFF
--- a/examples/aqt_matmul_native.py
+++ b/examples/aqt_matmul_native.py
@@ -17,15 +17,12 @@
 from collections import namedtuple
 import logging
 
-from iree.jax2.staging_api import *
-from iree.jax2.builtins import *
+from iree.jax import Program, kernel, like
 
 import jax
 import jax.numpy as jnp
 
 logging.basicConfig(level=logging.DEBUG)
-jax.config.update("jax_enable_mlir", True)
-
 
 activation_example = jnp.arange(30, dtype=jnp.float32).reshape(5, 6) / 10.4
 
@@ -35,12 +32,12 @@ params = Params(
   activation_scale=jnp.array(5.0),
 )
 
-class AqtMatmulModule(StagedModule):
+class AqtMatmulModule(Program):
 
-  _params = export_global(params, initialize=True, mutable=False)
+  _params = params
 
-  @export_kernel
-  def aqt_matmul_native(mdl, params, activation):
+  @kernel
+  def aqt_matmul_native(params, activation):
     precision = 8
     lower_bound = -2**(precision - 1) + 1
     upper_bound = 2**(precision - 1) - 1
@@ -59,9 +56,8 @@ class AqtMatmulModule(StagedModule):
         activation_as_int, weight_as_int, preferred_element_type=jnp.int32)
     return scaled_result / (params.activation_scale * weight_scale)
 
-  @export_traced_proc(signature=(activation_example,))
-  def compute_native(mdl, activation):
+  def compute_native(mdl, activation=like(activation_example)):
     return mdl.aqt_matmul_native(mdl._params, activation)
 
 
-print(get_mlir_module(AqtMatmulModule))
+print(Program.get_mlir_module(AqtMatmulModule))

--- a/examples/aqt_matmul_simulated.py
+++ b/examples/aqt_matmul_simulated.py
@@ -17,15 +17,12 @@
 from collections import namedtuple
 import logging
 
-from iree.jax2.staging_api import *
-from iree.jax2.builtins import *
+from iree.jax import Program, kernel, like
 
 import jax
 import jax.numpy as jnp
 
 logging.basicConfig(level=logging.DEBUG)
-jax.config.update("jax_enable_mlir", True)
-
 
 activation_example = jnp.arange(30, dtype=jnp.float32).reshape(5, 6) / 10.4
 
@@ -35,12 +32,12 @@ params = Params(
   activation_scale=jnp.array(5.0),
 )
 
-class AqtMatmulModule(StagedModule):
+class AqtMatmulModule(Program):
 
-  _params = export_global(params, initialize=True, mutable=False)
+  _params = params
 
-  @export_kernel
-  def aqt_matmul_simulated(mdl, params, activation):
+  @kernel
+  def aqt_matmul_simulated(params, activation):
     precision = 8
     lower_bound = -2**(precision - 1) + 1
     upper_bound = 2**(precision - 1) - 1
@@ -56,9 +53,8 @@ class AqtMatmulModule(StagedModule):
     scaled_result = jax.lax.dot(activation_clipped, weight_rounded)
     return scaled_result / (params.activation_scale * weight_scale)
 
-  @export_traced_proc(signature=(activation_example,))
-  def compute_simulated(mdl, activation):
+  def compute_simulated(mdl, activation=like(activation_example)):
     return mdl.aqt_matmul_simulated(mdl._params, activation)
 
 
-print(get_mlir_module(AqtMatmulModule))
+print(Program.get_mlir_module(AqtMatmulModule))

--- a/examples/aqt_resnet.py
+++ b/examples/aqt_resnet.py
@@ -30,8 +30,7 @@ from aqt.jax.imagenet import models
 from aqt.jax.imagenet import train_utils as imagenet_train_utils
 from aqt.jax.imagenet.configs.paper import resnet50_w8_a8_auto
 
-from iree.jax2.staging_api import *
-from iree.jax2.builtins import *
+from iree.jax import Program, kernel, like
 
 FLAGS = flags.FLAGS
 config_flags.DEFINE_config_file('hparams_config_dict',
@@ -40,7 +39,6 @@ config_flags.DEFINE_config_file('hparams_config_dict',
 
 
 def main(argv):
-  jax.config.update("jax_enable_mlir", True)
 
   hparams = os_hparams_utils.load_hparams_from_config_dict(
       hparams_config.TrainingHParams, models.ResNet.HParams,
@@ -69,20 +67,19 @@ def main(argv):
   example_input = jax.ShapedArray((1, 224, 224, 3), dtype=jnp.float32)
 
   class ResnetInferenceModel(StagedModule):
-    _variables = export_global(variables)
+    _variables = variables
 
-    @export_kernel
-    def _predict(mdl, v, image):
+    @kernel
+    def _predict(v, image):
       # TODO: We should just be able to use mdl._variables here, but the
       # illusion is not good enough.
       logits = model.apply(v, image, mutable=False)
       return logits
 
-    @export_traced_proc(signature=[example_input])
-    def predict(mdl, image):
+    def predict(mdl, image=like(example_input)):
       return mdl._predict(mdl._variables, image)
 
-  print(get_mlir_module(ResnetInferenceModel))
+  print(Program.get_mlir_module(ResnetInferenceModel))
 
 
 if __name__ == "__main__":

--- a/examples/mnist_export.py
+++ b/examples/mnist_export.py
@@ -36,23 +36,23 @@ from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
 
 from iree.jax import (
   like,
-  Module,
+  kernel,
+  Program,
 )
 
 
 def main(args):
   output_dir = args[0]
   os.makedirs(output_dir, exist_ok=True)
-  jax.config.update("jax_enable_mlir", True)
   compiled_module = build_model()
 
   print("Saving mlir...")
   with open(os.path.join(output_dir, "mnist_train.mlir"), "wb") as f:
-    Module.get_mlir_module(compiled_module).operation.print(f, binary=True)
+    Program.get_mlir_module(compiled_module).operation.print(f, binary=True)
 
   print("Saving binary...")
   with open(os.path.join(output_dir, "mnist_train.vmfb"), "wb") as f:
-    f.write(Module.get_compiled_artifact(compiled_module).vm_binary)
+    f.write(Program.get_compiled_artifact(compiled_module).vm_binary)
 
 
 def build_model():
@@ -77,10 +77,10 @@ def build_model():
 
   example_batch = get_example_batch()
 
-  class MnistModule(Module):
+  class MnistModule(Program):
     # We don't want to export the host-side initial values, so export those
     # first and disable initialization.
-    _params = Module.export_global(init_params, initialize=False)
+    _params = init_params
     _opt_state = opt_state
 
     def get_params(self):
@@ -102,17 +102,17 @@ def build_model():
     def predict(self, inputs=like(example_batch[0])):
       return self._predict_target_class(self._params, inputs)
 
-    @Module.kernel
+    @kernel
     def _initialize_optimizer(rng):
       _, init_params = init_random_params(rng, (-1, 28 * 28))
       return opt_init(init_params)
 
-    @Module.kernel
+    @kernel
     def _update_step(batch, opt_state):
       params = opt_get_params(opt_state)
       return opt_update(0, grad(loss)(params, batch), opt_state)
 
-    @Module.kernel
+    @kernel
     def _predict_target_class(params, inputs):
       predicted_class = jnp.argmax(predict(params, inputs), axis=1)
       return predicted_class


### PR DESCRIPTION
Implemented using prior iree.jax2 interface. Updated so that it uses the updated interface