### PR TITLE
Remove obsolete reference to IREE internal passes.

### DIFF
--- a/iree/jax/jax_utils.py
+++ b/iree/jax/jax_utils.py
@@ -21,7 +21,6 @@ from iree.compiler import (
     ir,
     passmanager,
 )
-from iree.compiler.transforms import ireec
 
 import jax.core
 import jax.interpreters.mlir
@@ -50,16 +49,6 @@ def aval_to_ir_types(context: ir.Context,
     return ir.Type.parse(str(jax_type), context=context)
 
   return tuple(convert(t) for t in jax_types)
-
-
-def cleanup_mhlo_module(module: ir.Module):
-  with module.context:
-    pm = passmanager.PassManager()
-    ireec.build_xla_cleanup_pass_pipeline(pm)
-    # TODO: Don't lower it all the way here - but need to land bug fixes
-    # first.
-    #driver.build_mhlo_import_pass_pipeline(pm)
-    pm.run(module)
 
 
 def abstractify(x) -> jax.core.AbstractValue:


### PR DESCRIPTION
These are no longer used. Once ml_program lands upstream, we will be able to remove all IREE MLIR imports and make this a pure JAX API. This is a step in that direction.