### PR TITLE
Update versions and tie installation destination to release

### DIFF
--- a/.github/workflows/test_gpt2_model.yaml
+++ b/.github/workflows/test_gpt2_model.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run installation
         run: |
           python $GITHUB_WORKSPACE/build_tools/configure.py --use-pinned
-          python3 -m pip install . -f https://github.com/google/iree/releases --force-reinstall .[xla,cpu,test]
+          python $GITHUB_WORKSPACE/build_tools/pip_install.py
 
       - name: Fetch GPT-2
         run: |

--- a/.github/workflows/test_head_and_bump.yaml
+++ b/.github/workflows/test_head_and_bump.yaml
@@ -42,4 +42,4 @@ jobs:
           git config --local user.name "Bump Pinned Versions"
           git config --local user.email "iree-github-actions-bot@google.com"
           git commit -am "Update pinned versions"
-          git push
+          git push origin update-versions

--- a/.github/workflows/test_head_and_bump.yaml
+++ b/.github/workflows/test_head_and_bump.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run IREE-JAX Installation
         run: |
           python $GITHUB_WORKSPACE/build_tools/configure.py
-          python3 -m pip install . -f https://github.com/google/iree/releases --force-reinstall .[xla,cpu,test]
+          python $GITHUB_WORKSPACE/build_tools/pip_install.py
       
       - name: Run Tests
         run: |

--- a/.github/workflows/test_head_and_bump.yaml
+++ b/.github/workflows/test_head_and_bump.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run IREE-JAX Installation
         run: |
           python $GITHUB_WORKSPACE/build_tools/configure.py
-          python $GITHUB_WORKSPACE/build_tools/pip_install.py
+          python3 -m pip install . -f https://github.com/google/iree/releases --force-reinstall .[xla,cpu,test]
       
       - name: Run Tests
         run: |

--- a/.github/workflows/test_presubmit.yaml
+++ b/.github/workflows/test_presubmit.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run installation
         run: |
           python $GITHUB_WORKSPACE/build_tools/configure.py --use-pinned
-          python3 -m pip install . -f https://github.com/google/iree/releases --force-reinstall .[xla,cpu,test]
+          python $GITHUB_WORKSPACE/build_tools/pip_install.py
       
       - name: Run tests
         run: |

--- a/build_tools/pip_install.py
+++ b/build_tools/pip_install.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import subprocess
+import sys
+
+def main():
+  project_root = os.path.dirname(os.path.dirname(__file__))
+
+  # Load version_info.json.
+  version_info_file = os.path.join(project_root, "version_info.json")
+  try:
+    with open(version_info_file, "rt") as f:
+      version_info = json.load(f)
+  except FileNotFoundError:
+    print >> sys.stderr, "version_info.json not found"
+    sys.exit(1)
+
+  pinned_versions = version_info["pinned-versions"]
+  iree_version = pinned_versions["iree-compiler"]
+  print(iree_version)
+
+  command = f"python3 -m pip install . -f https://github.com/google/iree/releases/candidate-{iree_version} --force-reinstall .[xla,cpu,test]"
+  print(command)
+  proc = subprocess.Popen(command.split(' '))
+  _, err = proc.communicate()
+  print(err)
+
+if __name__ == "__main__":
+    main()

--- a/iree/jax/jax_utils.py
+++ b/iree/jax/jax_utils.py
@@ -106,7 +106,6 @@ def import_main_function(*,
   """
   context = target_module.context
   source_module = import_module(context, source_module)
-  cleanup_mhlo_module(source_module)
 
   # Local aliases for brevity.
   StringAttr = ir.StringAttr

--- a/version_info.json
+++ b/version_info.json
@@ -1,10 +1,10 @@
 {
   "pinned-versions": {
-    "iree-compiler": "20220502.125",
-    "iree-runtime": "20220502.125",
-    "iree-tools-xla": "20220502.125",
-    "jax": "0.3.7",
-    "jaxlib": "0.3.7"
+    "iree-compiler": "20220509.132",
+    "iree-runtime": "20220509.132",
+    "iree-tools-xla": "20220509.132",
+    "jax": "0.3.10",
+    "jaxlib": "0.3.10"
   },
   "use-pinned": true
 }


### PR DESCRIPTION
Releases tests were failing due to being unable to find the installation. Tweaking the installation to
redirect directly to the candidate location. Google enough until we figure out the pypi situation.